### PR TITLE
Use descriptive annotation instead of "Yasnippet".

### DIFF
--- a/cape-yasnippet.el
+++ b/cape-yasnippet.el
@@ -40,7 +40,7 @@
           (const :tag "Name" name)))
 
 (defvar cape-yasnippet--properties
-  (list :annotation-function (lambda (_) " Yasnippet")
+  (list :annotation-function #'cape--yasnippet-annotation
         :company-kind (lambda (_) 'snippet)
         :exit-function (lambda (cand status)
                          (when (string= "finished" status)
@@ -49,6 +49,11 @@
                              (yas-expand-snippet snippet))))
         :exclusive 'no)
   "Completion extra properties for `cape-yasnippet'.")
+
+(defun cape--yasnippet-annotation (arg)
+  "Get the :name item as ARG for annotations."
+  (lambda (name))
+  (get-text-property 0 'yas-annotation arg))
 
 (defun cape-yasnippet--lookup-snippet (name)
   "Get the snippet called NAME in MODE's tables."


### PR DESCRIPTION
Hi Elken,  
Here is a small change that uses the :name item to fill the  
annotations in the corfu completion list.  
This is what company does by default, as well as VS Code for  
what it's worth.  
I wanted to create an issue first to ask your opinion on this  
but it looks like you disabled it.  
Merge as you wish!