### PR TITLE
Fix failure due to upstream breaking change

### DIFF
--- a/cape-yasnippet.el
+++ b/cape-yasnippet.el
@@ -139,8 +139,9 @@
                                            (string-prefix-p prefix cand))))))
     (_ (error "Invalid value for cape-yasnippet-lookup-by: %s" cape-yasnippet-lookup-by))))
 
-(defun foo (&optional prefix)
-  "See if this works"
+(defun cape-yasnippet--cache-func (&optional prefix)
+  "Return a pair of a predicate function and the list of candidates.
+This is designed for use with cape--cached-table requires."
   (list #'cape-yasnippet-candidates
         (cape-yasnippet-candidates prefix)))
 
@@ -156,7 +157,7 @@ If INTERACTIVE is nil the function acts like a Capf."
             (end (match-end 0)))
         `(,beg ,end
                ,(cape--table-with-properties
-                 (cape--cached-table beg end #'foo)
+                 (cape--cached-table beg end #'cape-yasnippet--cache-func)
                  :category 'cape-yasnippet)
                ,@cape-yasnippet--properties)))))
 

--- a/cape-yasnippet.el
+++ b/cape-yasnippet.el
@@ -139,6 +139,11 @@
                                            (string-prefix-p prefix cand))))))
     (_ (error "Invalid value for cape-yasnippet-lookup-by: %s" cape-yasnippet-lookup-by))))
 
+(defun foo (&optional prefix)
+  "See if this works"
+  (list #'cape-yasnippet-candidates
+        (cape-yasnippet-candidates prefix)))
+
 ;;;###autoload
 (defun cape-yasnippet (&optional interactive)
   "Complete with yasnippet at point.
@@ -150,12 +155,10 @@ If INTERACTIVE is nil the function acts like a Capf."
       (let ((beg (match-beginning 0))
             (end (match-end 0)))
         `(,beg ,end
-          ,(cape--table-with-properties
-            (cape--cached-table beg end
-                                #'cape-yasnippet-candidates
-                                #'string-prefix-p)
-            :category 'cape-yasnippet)
-          ,@cape-yasnippet--properties)))))
+               ,(cape--table-with-properties
+                 (cape--cached-table beg end #'foo)
+                 :category 'cape-yasnippet)
+               ,@cape-yasnippet--properties)))))
 
 (provide 'cape-yasnippet)
 ;;; cape-yasnippet.el ends here


### PR DESCRIPTION
It seems like upstream has changed the definition of `cape--cached-table` again.

I suspect you don't really want this fix as it is, but I hope you can let me know what changes you'd like me to make so you can accept it.